### PR TITLE
feat(wallets): add `getAccounts`

### DIFF
--- a/libs/wallets/README.md
+++ b/libs/wallets/README.md
@@ -90,6 +90,10 @@ Needs to be called first before `subscribeAccounts`. Connects to the wallet exte
 
 This will trigger the extension to popup if it's the first time being enabled.
 
+### `wallet.getAccounts(anyType?: boolean): Promise<WalletAccount[]>`
+
+Get wallet's accounts.
+
 ### `wallet.subscribeAccounts(callback): UnsubscribeFn`
 
 Subscribe to the wallet's accounts.

--- a/libs/wallets/src/types.ts
+++ b/libs/wallets/src/types.ts
@@ -54,6 +54,9 @@ interface Signer {
 interface Connector {
   enable: (dappName: string) => unknown;
 
+  // Get accounts function
+  getAccounts: (anyType?: boolean) => Promise<WalletAccount[]>;
+
   // The subscribe to accounts function
   subscribeAccounts: (callback: SubscriptionFn) => unknown;
 }


### PR DESCRIPTION
Some wallet apps (e.g. imToken) don't implement `subscribeAccounts` correctly, when choosing `polkadot-js` wallet, it may result in failure to get accounts.

Try adding `getAccounts` method to get extensions accounts in another way.

- [x] Tested in local environment